### PR TITLE
FIX: Arm library for MacOS

### DIFF
--- a/org.lwjgl3/3.3.2.json
+++ b/org.lwjgl3/3.3.2.json
@@ -39,6 +39,12 @@
                     "os": {
                         "name": "osx"
                     }
+                },
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "osx-arm64"
+                    }
                 }
             ]
         },
@@ -156,6 +162,12 @@
                     "action": "allow",
                     "os": {
                         "name": "osx"
+                    }
+                },
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "osx-arm64"
                     }
                 }
             ]
@@ -275,6 +287,12 @@
                     "os": {
                         "name": "osx"
                     }
+                },
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "osx-arm64"
+                    }
                 }
             ]
         },
@@ -393,6 +411,12 @@
                     "os": {
                         "name": "osx"
                     }
+                },
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "osx-arm64"
+                    }
                 }
             ]
         },
@@ -500,6 +524,12 @@
                     "action": "allow",
                     "os": {
                         "name": "osx"
+                    }
+                },
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "osx-arm64"
                     }
                 }
             ]
@@ -619,6 +649,12 @@
                     "os": {
                         "name": "osx"
                     }
+                },
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "osx-arm64"
+                    }
                 }
             ]
         },
@@ -737,6 +773,12 @@
                     "os": {
                         "name": "osx"
                     }
+                },
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "osx-arm64"
+                    }
                 }
             ]
         },
@@ -854,6 +896,12 @@
                     "action": "allow",
                     "os": {
                         "name": "osx"
+                    }
+                },
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "osx-arm64"
                     }
                 }
             ]

--- a/org.lwjgl3/3.3.3.json
+++ b/org.lwjgl3/3.3.3.json
@@ -39,6 +39,12 @@
                     "os": {
                         "name": "osx"
                     }
+                },
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "osx-arm64"
+                    }
                 }
             ]
         },
@@ -148,6 +154,12 @@
                     "action": "allow",
                     "os": {
                         "name": "osx"
+                    }
+                },
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "osx-arm64"
                     }
                 }
             ]
@@ -267,6 +279,12 @@
                     "os": {
                         "name": "osx"
                     }
+                },
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "osx-arm64"
+                    }
                 }
             ]
         },
@@ -385,6 +403,12 @@
                     "os": {
                         "name": "osx"
                     }
+                },
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "osx-arm64"
+                    }
                 }
             ]
         },
@@ -492,6 +516,12 @@
                     "action": "allow",
                     "os": {
                         "name": "osx"
+                    }
+                },
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "osx-arm64"
                     }
                 }
             ]
@@ -611,6 +641,12 @@
                     "os": {
                         "name": "osx"
                     }
+                },
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "osx-arm64"
+                    }
                 }
             ]
         },
@@ -729,6 +765,12 @@
                     "os": {
                         "name": "osx"
                     }
+                },
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "osx-arm64"
+                    }
                 }
             ]
         },
@@ -846,6 +888,12 @@
                     "action": "allow",
                     "os": {
                         "name": "osx"
+                    }
+                },
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "osx-arm64"
                     }
                 }
             ]


### PR DESCRIPTION
Resolved the issues:

- https://github.com/PolyMC/PolyMC/issues/1604
- https://github.com/PolyMC/PolyMC/issues/1656

also If you look at the logic of 1.21.3.json from the Mojang Assets Server, the rules for MacOS Arm were not added.